### PR TITLE
NH-102247: add sampling

### DIFF
--- a/buildSrc/src/main/kotlin/solarwinds.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/solarwinds.spotless-conventions.gradle.kts
@@ -7,13 +7,11 @@ plugins {
 spotless {
     java {
         googleJavaFormat().aosp()
-        licenseHeaderFile(rootProject.file("gradle/spotless.license.java"), "(package|import|public)")
         target("src/**/*.java")
     }
     plugins.withId("org.jetbrains.kotlin.jvm") {
         kotlin {
             ktlint()
-            licenseHeaderFile(rootProject.file("gradle/spotless.license.java"), "(package|import|public)")
         }
     }
     kotlinGradle {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.7.3"
 datastorePreferences = "1.1.3"
 fragmentCompose = "1.8.6"
+jacksonJrObjects = "2.18.3"
 kotlin = "2.1.10"
 coreKtx = "1.15.0"
 junit5 = "5.11.4"
@@ -14,13 +15,15 @@ material = "1.12.0"
 constraintlayout = "2.2.1"
 lifecycle-livedata-ktx = "2.8.7"
 lifecycle-viewmodel-ktx = "2.8.7"
-navigation-fragment-ktx = "2.8.8"
-navigation-ui-ktx = "2.8.8"
+navigation-fragment-ktx = "2.8.9"
+navigation-ui-ktx = "2.8.9"
+sampling = "10.0.19"
+shadowGradlePlugin = "8.3.6"
 spotless = "7.0.2"
 activity-compose = "1.10.1"
-compose-bom = "2025.02.00"
+compose-bom = "2025.03.00"
 opentelemetry-sdk = "1.47.0"
-opentelemetry-inst = "2.13.1"
+opentelemetry-inst = "2.13.3"
 opentelemetry-android = "0.10.0-alpha-SNAPSHOT"
 opentelemetry-instrumentation-alpha = "2.13.1-alpha"
 mockito = "5.15.2"
@@ -30,7 +33,7 @@ byteBuddy = "1.17.1"
 work_version = "2.10.0"
 autoService = "1.1.1"
 room_version = "2.6.1"
-navigation-compose = "2.8.8"
+navigation-compose = "2.8.9"
 
 [libraries]
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
@@ -40,6 +43,7 @@ androidx-room = {module = "androidx.room:room-runtime", version.ref = "room_vers
 androidx-room-ktx = {module = "androidx.room:room-ktx", version.ref = "room_version"}
 androidx-room-compiler = {module = "androidx.room:room-compiler", version.ref = "room_version"}
 androidx-work-manager = { module = "androidx.work:work-runtime", version.ref = "work_version" }
+androidx-work-test = { module = "androidx.work:work-testing", version.ref = "work_version" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "android-junit-version" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
@@ -55,6 +59,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
+jackson-jr-objects = { module = "com.fasterxml.jackson.jr:jackson-jr-objects", version.ref = "jacksonJrObjects" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 kotlin-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
 
@@ -77,6 +82,8 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 auto-service-processor = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"
 android-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+sampling = { module = "com.solarwinds.joboe:sampling", version.ref = "sampling" }
+shadow-gradle-plugin = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "shadowGradlePlugin" }
 spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
@@ -88,6 +95,7 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robocop" 
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "android-test" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
 [bundles]
 mocking = ["mockito-core", "mockito-junit-jupiter"]

--- a/otel-android/build.gradle.kts
+++ b/otel-android/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 /*
  * © SolarWinds Worldwide, LLC. All rights reserved.
  *
@@ -16,6 +18,7 @@
 
 plugins {
     id("solarwinds.android-library-conventions")
+    id("com.gradleup.shadow") version("8.3.5")
 }
 
 android {
@@ -53,10 +56,21 @@ dependencies {
 
     mockitoAgent(libs.mockito.core) { isTransitive = false }
     implementation(libs.opentelemetry.exporter.otlp)
+    implementation(libs.sampling)
+    implementation(libs.okhttp)
+    implementation(libs.opentelemetry.instrumentation.apiSemconv)
+    implementation(libs.jackson.jr.objects)
+    implementation(libs.androidx.work.manager)
 
     testImplementation(libs.androidx.junit)
+    testImplementation(libs.androidx.work.test)
+    testImplementation(libs.okhttp.mockwebserver)
 }
 
 tasks.withType<Test> {
     jvmArgs("-javaagent:${mockitoAgent.asPath}")
+}
+
+tasks.withType<ShadowJar>{
+    relocate("okhttp.","com.solarwinds.android.shaded.")
 }

--- a/otel-android/src/main/java/com/solarwinds/android/SolarwindsRumBuilder.java
+++ b/otel-android/src/main/java/com/solarwinds/android/SolarwindsRumBuilder.java
@@ -19,6 +19,20 @@ package com.solarwinds.android;
 import android.app.Application;
 
 
+import androidx.work.Constraints;
+import androidx.work.Data;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+
+import com.solarwinds.android.sampling.AndroidSettingsFetcher;
+import com.solarwinds.android.sampling.AndroidSettingsWorker;
+import com.solarwinds.android.sampling.SolarwindsSampler;
+import com.solarwinds.joboe.sampling.SamplingConfiguration;
+import com.solarwinds.joboe.sampling.SettingsManager;
+
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import io.opentelemetry.android.OpenTelemetryRum;
@@ -33,6 +47,7 @@ import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 
@@ -85,12 +100,27 @@ public class SolarwindsRumBuilder {
 
         OpenTelemetryRumBuilder builder = OpenTelemetryRum.builder(application, otelRumConfig);
         builder
+                .mergeResource(SolarwindsResourceProvider.create())
                 .addSpanExporterCustomizer(this::createSpanExporter)
-                .addMeterProviderCustomizer(this::customizeMetricProvider)
                 .addLogRecordExporterCustomizer(this::createLogExporter)
-                .mergeResource(SolarwindsResourceProvider.create());
+                .addMeterProviderCustomizer(this::customizeMetricProvider)
+                .addTracerProviderCustomizer(this::customizeTracerProvider);
 
+        Data data = new Data.Builder()
+                .putString("appName", readAppName(application))
+                .putString("collectorUrl", collectorUrl)
+                .putString("apiToken", apiToken)
+                .build();
+
+        scheduleWorker(application, data);
+        SettingsManager.initialize(new AndroidSettingsFetcher(),
+                SamplingConfiguration.builder()
+                        .build());
         return new SolarwindsRum(builder.build());
+    }
+
+    private SdkTracerProviderBuilder customizeTracerProvider(SdkTracerProviderBuilder sdkTracerProviderBuilder, Application application) {
+        return sdkTracerProviderBuilder.setSampler(new SolarwindsSampler());
     }
 
     private OtlpGrpcSpanExporter createSpanExporter(SpanExporter spanExporter) {
@@ -119,5 +149,34 @@ public class SolarwindsRumBuilder {
                 .setEndpoint(collectorUrl)
                 .addHeader("authorization", String.format("Bearer %s", apiToken))
                 .build();
+    }
+
+    private static String readAppName(Application application) {
+        try {
+            int stringId =
+                    application.getApplicationContext().getApplicationInfo().labelRes;
+            return application.getApplicationContext().getString(stringId);
+        } catch (Throwable e) {
+            return "unknown_service:android";
+        }
+    }
+
+    private void scheduleWorker(Application application, Data data) {
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresBatteryNotLow(true)
+                .build();
+
+        PeriodicWorkRequest periodicWorkRequest = new PeriodicWorkRequest.Builder(AndroidSettingsWorker.class, 1, TimeUnit.MINUTES)
+                .setConstraints(constraints)
+                .setInputData(data)
+                .build();
+
+        WorkManager workManager = WorkManager.getInstance(application.getApplicationContext());
+        workManager.enqueueUniquePeriodicWork(
+                AndroidSettingsFetcher.class.getSimpleName(),
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
+                periodicWorkRequest
+        );
     }
 }

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/AndroidSettingsFetcher.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/AndroidSettingsFetcher.java
@@ -1,0 +1,70 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import com.solarwinds.joboe.sampling.Settings;
+import com.solarwinds.joboe.sampling.SettingsFetcher;
+import com.solarwinds.joboe.sampling.SettingsListener;
+
+import java.util.concurrent.CountDownLatch;
+
+public class AndroidSettingsFetcher implements SettingsFetcher {
+
+    private static SettingsListener listener = null;
+
+    @Override
+    public Settings getSettings() {
+        Settings settings = AndroidSettingsWorker.getSettings();
+        if (listener != null) {
+            listener.onSettingsRetrieved(settings);
+        }
+
+        return settings;
+    }
+
+    @Override
+    public void registerListener(SettingsListener settingsListener) {
+        listener = settingsListener;
+    }
+
+    @Override
+    public CountDownLatch isSettingsAvailableLatch() {
+        return new CountDownLatch(0);
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/AndroidSettingsWorker.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/AndroidSettingsWorker.java
@@ -1,0 +1,116 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import static com.solarwinds.android.sampling.Constants.SW_LOG_TAG;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.work.Data;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.fasterxml.jackson.jr.ob.JSON;
+import com.solarwinds.joboe.sampling.Settings;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class AndroidSettingsWorker extends Worker {
+    private static Settings settings = null;
+    private final String applicationName;
+
+    private final String collectorUrl;
+
+    private final String apiToken;
+    private final OkHttpClient okHttpClient = new OkHttpClient();
+
+    private final Pattern regex = Pattern.compile("otel(.*)");
+
+    static Settings getSettings() {
+        return settings;
+    }
+
+    public AndroidSettingsWorker(Context context, WorkerParameters workerParams) {
+        super(context, workerParams);
+        Data inputData = workerParams.getInputData();
+        applicationName = inputData.getString("appName");
+        collectorUrl = constructSettingsEndpoint(inputData.getString("collectorUrl"));
+        apiToken = inputData.getString("apiToken");
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        try {
+            fetchSettings();
+            return Result.success();
+        } catch (IOException e) {
+            Log.e(SW_LOG_TAG, "Error getting settings");
+            return Result.retry();
+        }
+    }
+
+    private void fetchSettings() throws IOException {
+        if (settings == null || System.currentTimeMillis() - settings.getTimestamp() > settings.getTtl() * 1000) {
+            Request request = new Request.Builder()
+                    .addHeader("Authorization", String.format("Bearer %s", apiToken))
+                    .url(String.format("%s/v1/settings/%s/%s", collectorUrl, applicationName, "Android"))
+                    .build();
+
+            Response response = okHttpClient.newCall(request).execute();
+            if (response.isSuccessful() && response.body() != null) {
+                byte[] bytes = response.body().bytes();
+                JsonSettings jsonSettings = JSON.std
+                        .beanFrom(JsonSettings.class, bytes);
+                settings = new JsonSettingsWrapper(jsonSettings);
+                Log.d(SW_LOG_TAG, "retrieved settings");
+            }
+        }
+    }
+
+    private String constructSettingsEndpoint(String collectorUrl) {
+        Matcher matcher = regex.matcher(collectorUrl);
+        if (matcher.find()) {
+            return String.format("https://apm%s", matcher.group(1));
+        }
+        return collectorUrl;
+    }
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/Constants.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/Constants.java
@@ -1,0 +1,47 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+public class Constants {
+  private Constants(){}
+
+  public static final String SW_LOG_TAG = "Solarwinds";
+  public static final String SW_KEY_PREFIX = "sw.";
+  public static final String SW_INTERNAL_ATTRIBUTE_PREFIX = SW_KEY_PREFIX + "internal.";
+  public static final String SW_DETAILED_TRACING = SW_INTERNAL_ATTRIBUTE_PREFIX + "detailedTracing";
+  public static final String SW_METRICS = SW_INTERNAL_ATTRIBUTE_PREFIX + "metrics";
+  public static final String SW_SAMPLER = SW_INTERNAL_ATTRIBUTE_PREFIX + "sampler";
+  public static final String W3C_KEY_PREFIX = "w3c.";
+  public static final String SW_UPSTREAM_TRACESTATE = SW_KEY_PREFIX + W3C_KEY_PREFIX + "tracestate";
+  public static final String SW_PARENT_ID = SW_KEY_PREFIX + "tracestate_parent_id";
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/JsonSettings.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/JsonSettings.java
@@ -1,0 +1,107 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import java.util.Map;
+
+public class JsonSettings {
+  private Map<String, Object> arguments;
+
+  private String flags;
+
+  private String layer;
+
+  private long timestamp;
+
+  private long ttl;
+
+  private short type;
+
+  private long value;
+
+  public long getValue() {
+    return value;
+  }
+
+  public void setValue(long value) {
+    this.value = value;
+  }
+
+  public short getType() {
+    return type;
+  }
+
+  public void setType(short type) {
+    this.type = type;
+  }
+
+  public long getTtl() {
+    return ttl;
+  }
+
+  public void setTtl(long ttl) {
+    this.ttl = ttl;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public String getLayer() {
+    return layer;
+  }
+
+  public void setLayer(String layer) {
+    this.layer = layer;
+  }
+
+  public String getFlags() {
+    return flags;
+  }
+
+  public void setFlags(String flags) {
+    this.flags = flags;
+  }
+
+  public Map<String, Object> getArguments() {
+    return arguments;
+  }
+
+  public void setArguments(Map<String, Object> arguments) {
+    this.arguments = arguments;
+  }
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/JsonSettingsWrapper.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/JsonSettingsWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import static com.solarwinds.android.sampling.Constants.SW_LOG_TAG;
+
+import android.util.Log;
+
+import com.solarwinds.joboe.sampling.Settings;
+import com.solarwinds.joboe.sampling.SettingsArg;
+
+public class JsonSettingsWrapper extends Settings {
+    private final JsonSettings jsonSettings;
+
+    public JsonSettingsWrapper(JsonSettings jsonSettings) {
+        this.jsonSettings = jsonSettings;
+    }
+
+    @Override
+    public long getValue() {
+        return jsonSettings.getValue();
+    }
+
+    @Override
+    public long getTimestamp() {
+        return jsonSettings.getTimestamp();
+    }
+
+    @Override
+    public short getType() {
+        return jsonSettings.getType();
+    }
+
+    @Override
+    public short getFlags() {
+        short flags = 0;
+        String[] flagTokens = jsonSettings.getFlags().split(",");
+        for (String flagToken : flagTokens) {
+            if ("OVERRIDE".equals(flagToken)) {
+                flags |= OBOE_SETTINGS_FLAG_OVERRIDE;
+            } else if ("SAMPLE_START".equals(flagToken)) {
+                flags |= OBOE_SETTINGS_FLAG_SAMPLE_START;
+            } else if ("SAMPLE_THROUGH".equals(flagToken)) {
+                flags |= OBOE_SETTINGS_FLAG_SAMPLE_THROUGH;
+            } else if ("SAMPLE_THROUGH_ALWAYS".equals(flagToken)) {
+                flags |= OBOE_SETTINGS_FLAG_SAMPLE_THROUGH_ALWAYS;
+            } else if ("TRIGGER_TRACE".equals(flagToken)) {
+                flags |= OBOE_SETTINGS_FLAG_TRIGGER_TRACE_ENABLED;
+            } else if ("SAMPLE_BUCKET_ENABLED".equals(flagToken)) { // not used anymore
+                flags |= OBOE_SETTINGS_FLAG_SAMPLE_BUCKET_ENABLED;
+            } else {
+                Log.d(SW_LOG_TAG,"Unknown flag found from settings: " + flagToken);
+            }
+        }
+        return flags;
+    }
+
+    @Override
+    public long getTtl() {
+        return jsonSettings.getTtl();
+    }
+
+    @Override
+    public <T> T getArgValue(SettingsArg<T> settingsArg) {
+        Object value = jsonSettings.getArguments().get(settingsArg.getKey());
+        return settingsArg.readValue(value);
+    }
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/SamplingUtil.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/SamplingUtil.java
@@ -1,0 +1,110 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import com.solarwinds.joboe.sampling.Metadata;
+import com.solarwinds.joboe.sampling.TraceDecision;
+import com.solarwinds.joboe.sampling.TraceDecisionUtil;
+import com.solarwinds.joboe.sampling.XTraceOption;
+import com.solarwinds.joboe.sampling.XTraceOptions;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.ContextKey;
+
+import java.util.regex.Pattern;
+
+public class SamplingUtil {
+  private SamplingUtil() {}
+
+  public static final String SW_TRACESTATE_KEY = "sw";
+  static final Pattern SPAN_ID_REGEX = Pattern.compile("[0-9a-fA-F]{16}");
+  static final ContextKey<XTraceOptions> TRIGGER_TRACE_KEY = ContextKey.named("sw-trigger-trace-key");
+  static final ContextKey<String> TRACE_STATE_KEY = ContextKey.named("tracestate-original-value");
+  static final String LAYER_NAME_PLACEHOLDER = "%s:%s";
+
+  public static boolean isValidSwTraceState(String swVal) {
+    if (swVal == null || !swVal.contains("-")) {
+      return false;
+    }
+
+    final String[] swTraceState = swVal.split("-");
+    if (swTraceState.length != 2) {
+      return false;
+    }
+
+    // 16 is the hex length of the Otel span id
+    return (SPAN_ID_REGEX.matcher(swTraceState[0]).matches())
+        && (swTraceState[1].equals("00") || swTraceState[1].equals("01"));
+  }
+
+  public static void addXtraceOptionsToAttribute(
+      TraceDecision traceDecision,
+      XTraceOptions xtraceOptions,
+      AttributesBuilder attributesBuilder) {
+    if (xtraceOptions != null) {
+      xtraceOptions
+          .getCustomKvs()
+          .forEach(
+              ((stringXtraceOption, s) -> attributesBuilder.put(stringXtraceOption.getKey(), s)));
+
+      if (traceDecision.getRequestType()
+              == TraceDecisionUtil.RequestType.AUTHENTICATED_TRIGGER_TRACE
+          || traceDecision.getRequestType()
+              == TraceDecisionUtil.RequestType.UNAUTHENTICATED_TRIGGER_TRACE) {
+        attributesBuilder.put("TriggeredTrace", true);
+      }
+
+      String swKeys = xtraceOptions.getOptionValue(XTraceOption.SW_KEYS);
+      if (swKeys != null) {
+        attributesBuilder.put("SWKeys", swKeys);
+      }
+    }
+  }
+
+
+  /**
+   * Converts an OpenTelemetry span context to a hex string.
+   *
+   * @param context otel span context
+   * @return span context as hex string
+   */
+  public static String w3cContextToHexString(SpanContext context) {
+    return Metadata.CURRENT_VERSION_HEXSTRING
+            + Metadata.HEXSTRING_DELIMETER
+            + context.getTraceId()
+            + Metadata.HEXSTRING_DELIMETER
+            + context.getSpanId()
+            + Metadata.HEXSTRING_DELIMETER
+            + context.getTraceFlags().asHex();
+  }
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/SolarwindsSampler.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/SolarwindsSampler.java
@@ -1,0 +1,208 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import static com.solarwinds.android.sampling.Constants.SW_LOG_TAG;
+import static com.solarwinds.android.sampling.SamplingUtil.LAYER_NAME_PLACEHOLDER;
+import static com.solarwinds.android.sampling.SamplingUtil.SW_TRACESTATE_KEY;
+import static com.solarwinds.android.sampling.SamplingUtil.TRACE_STATE_KEY;
+import static com.solarwinds.android.sampling.SamplingUtil.TRIGGER_TRACE_KEY;
+import static com.solarwinds.android.sampling.SamplingUtil.addXtraceOptionsToAttribute;
+import static com.solarwinds.android.sampling.SamplingUtil.w3cContextToHexString;
+import static com.solarwinds.joboe.sampling.TraceDecisionUtil.shouldTraceRequest;
+
+import android.util.Log;
+
+import com.solarwinds.joboe.sampling.TraceDecision;
+import com.solarwinds.joboe.sampling.XTraceOptions;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+
+/**
+ * Sampler that uses trace decision logic from our joboe core (consult local and remote settings)
+ *
+ * <p>Also inject various Solarwinds specific sampling KVs into the `SampleResult`
+ */
+public class SolarwindsSampler implements Sampler {
+    public static final SamplingResult METRICS_ONLY =
+            SamplingResult.create(
+                    SamplingDecision.RECORD_ONLY,
+                    Attributes.of(
+                            AttributeKey.booleanKey(Constants.SW_DETAILED_TRACING), false,
+                            AttributeKey.booleanKey(Constants.SW_METRICS), true,
+                            AttributeKey.booleanKey(Constants.SW_SAMPLER), true));
+
+    public static final SamplingResult NOT_TRACED =
+            SamplingResult.create(
+                    SamplingDecision.DROP,
+                    Attributes.of(
+                            AttributeKey.booleanKey(Constants.SW_DETAILED_TRACING), false,
+                            AttributeKey.booleanKey(Constants.SW_METRICS), false,
+                            AttributeKey.booleanKey(Constants.SW_SAMPLER), true));
+
+    public SolarwindsSampler() {
+        Log.i(SW_LOG_TAG, "Attached Solarwinds' Sampler");
+    }
+
+    @Override
+    public SamplingResult shouldSample(
+            Context parentContext,
+            String traceId,
+            String name,
+            SpanKind spanKind,
+            Attributes attributes,
+            List<LinkData> parentLinks) {
+        final SpanContext parentSpanContext = Span.fromContext(parentContext).getSpanContext();
+        final TraceState traceState =
+                parentSpanContext.getTraceState() != null
+                        ? parentSpanContext.getTraceState()
+                        : TraceState.getDefault();
+
+        final SamplingResult samplingResult;
+        final AttributesBuilder additionalAttributesBuilder = Attributes.builder();
+        final XTraceOptions xTraceOptions = parentContext.get(TRIGGER_TRACE_KEY);
+
+        List<String> signals =
+                Arrays.asList(
+                        constructUrl(attributes), String.format(LAYER_NAME_PLACEHOLDER, spanKind, name.trim()));
+
+        if (!parentSpanContext.isValid()) { // no valid traceparent, it is a new trace
+            TraceDecision traceDecision = shouldTraceRequest(name, null, xTraceOptions, signals);
+            samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, true);
+
+        } else if (parentSpanContext.isRemote()) {
+            final String swTraceState = traceState.get(SW_TRACESTATE_KEY);
+
+            if (SamplingUtil.isValidSwTraceState(swTraceState)) { // pass through for request counting
+                additionalAttributesBuilder.put(Constants.SW_PARENT_ID, swTraceState.split("-")[0]);
+                final String xTraceId = w3cContextToHexString(parentSpanContext);
+                final TraceDecision traceDecision =
+                        shouldTraceRequest(name, xTraceId, xTraceOptions, signals);
+
+                samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, false);
+
+            } else { // no swTraceState, treat it as a new trace
+                final TraceDecision traceDecision = shouldTraceRequest(name, null, xTraceOptions, signals);
+                samplingResult = toOtSamplingResult(traceDecision, xTraceOptions, true);
+            }
+
+            final String traceStateValue = parentContext.get(TRACE_STATE_KEY);
+            if (traceStateValue != null) {
+                additionalAttributesBuilder.put(Constants.SW_UPSTREAM_TRACESTATE, traceStateValue);
+            }
+
+        } else { // local span, continue with parent based sampling
+            samplingResult =
+                    Sampler.parentBased(Sampler.alwaysOff())
+                            .shouldSample(parentContext, traceId, name, spanKind, attributes, parentLinks);
+        }
+
+        SamplingResult result =
+                TraceStateSamplingResult.wrap(
+                        samplingResult, additionalAttributesBuilder.build());
+
+        Log.d(SW_LOG_TAG, String.format("Sampling decision: %s", result.getDecision()));
+        return result;
+    }
+
+    private String constructUrl(Attributes attributes) {
+        String scheme = attributes.get(UrlAttributes.URL_SCHEME);
+        String host = attributes.get(ServerAttributes.SERVER_ADDRESS);
+        String target = attributes.get(UrlAttributes.URL_PATH);
+
+        String url = String.format("%s://%s%s", scheme, host, target);
+        Log.d(SW_LOG_TAG, String.format("Constructed url: %s", url));
+        return url;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Solarwinds Observability Sampler";
+    }
+
+    SamplingResult toOtSamplingResult(
+            TraceDecision traceDecision, XTraceOptions xtraceOptions, boolean genesis) {
+        SamplingResult result = NOT_TRACED;
+
+        if (traceDecision.isSampled()) {
+            final SamplingDecision samplingDecision = SamplingDecision.RECORD_AND_SAMPLE;
+            final AttributesBuilder attributesBuilder = Attributes.builder();
+            attributesBuilder.put(
+                    Constants.SW_KEY_PREFIX + "SampleRate", traceDecision.getTraceConfig().getSampleRate());
+            attributesBuilder.put(
+                    Constants.SW_KEY_PREFIX + "SampleSource",
+                    traceDecision.getTraceConfig().getSampleRateSourceValue());
+            attributesBuilder.put(
+                    Constants.SW_KEY_PREFIX + "BucketRate",
+                    traceDecision
+                            .getTraceConfig()
+                            .getBucketRate(traceDecision.getRequestType().getBucketType()));
+            attributesBuilder.put(
+                    Constants.SW_KEY_PREFIX + "BucketCapacity",
+                    traceDecision
+                            .getTraceConfig()
+                            .getBucketCapacity(traceDecision.getRequestType().getBucketType()));
+            attributesBuilder.put(
+                    Constants.SW_KEY_PREFIX + "RequestType", traceDecision.getRequestType().name());
+            attributesBuilder.put(Constants.SW_DETAILED_TRACING, traceDecision.isSampled());
+            attributesBuilder.put(Constants.SW_METRICS, traceDecision.isReportMetrics());
+            attributesBuilder.put(Constants.SW_SAMPLER, true); // mark that it has been sampled by us
+
+            if (genesis) {
+                addXtraceOptionsToAttribute(traceDecision, xtraceOptions, attributesBuilder);
+            }
+            result = SamplingResult.create(samplingDecision, attributesBuilder.build());
+        } else {
+            if (traceDecision.isReportMetrics()) {
+                result = METRICS_ONLY;
+            }
+        }
+        return result;
+    }
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/TraceDecisionMetricCollector.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/TraceDecisionMetricCollector.java
@@ -1,0 +1,110 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+
+import androidx.annotation.NonNull;
+
+import com.google.auto.service.AutoService;
+import com.solarwinds.joboe.sampling.TraceDecisionUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
+import io.opentelemetry.android.instrumentation.InstallationContext;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+
+@AutoService(AndroidInstrumentation.class)
+public class TraceDecisionMetricCollector implements AutoCloseable, AndroidInstrumentation {
+    private final List<ObservableLongGauge> gauges = new ArrayList<>();
+
+    public void collect(Meter meter) {
+        gauges.add(
+                meter
+                        .gaugeBuilder("trace.service.request_count")
+                        .ofLongs()
+                        .buildWithCallback(
+                                observableLongMeasurement ->
+                                        observableLongMeasurement.record(
+                                                TraceDecisionUtil.consumeMetricsData(
+                                                        TraceDecisionUtil.MetricType.THROUGHPUT))));
+
+        gauges.add(
+                meter
+                        .gaugeBuilder("trace.service.tokenbucket_exhaustion_count")
+                        .ofLongs()
+                        .buildWithCallback(
+                                observableLongMeasurement ->
+                                        observableLongMeasurement.record(
+                                                TraceDecisionUtil.consumeMetricsData(
+                                                        TraceDecisionUtil.MetricType.TOKEN_BUCKET_EXHAUSTION))));
+
+        gauges.add(
+                meter
+                        .gaugeBuilder("trace.service.tracecount")
+                        .ofLongs()
+                        .buildWithCallback(
+                                observableLongMeasurement ->
+                                        observableLongMeasurement.record(
+                                                TraceDecisionUtil.consumeMetricsData(
+                                                        TraceDecisionUtil.MetricType.TRACE_COUNT))));
+
+        gauges.add(
+                meter
+                        .gaugeBuilder("trace.service.samplecount")
+                        .ofLongs()
+                        .buildWithCallback(
+                                observableLongMeasurement ->
+                                        observableLongMeasurement.record(
+                                                TraceDecisionUtil.consumeMetricsData(
+                                                        TraceDecisionUtil.MetricType.SAMPLE_COUNT))));
+
+        gauges.add(
+                meter
+                        .gaugeBuilder("trace.service.through_trace_count")
+                        .ofLongs()
+                        .buildWithCallback(
+                                observableLongMeasurement ->
+                                        observableLongMeasurement.record(
+                                                TraceDecisionUtil.consumeMetricsData(
+                                                        TraceDecisionUtil.MetricType.THROUGH_TRACE_COUNT))));
+
+        gauges.add(
+                meter
+                        .gaugeBuilder("trace.service.triggered_trace_count")
+                        .ofLongs()
+                        .buildWithCallback(
+                                observableLongMeasurement ->
+                                        observableLongMeasurement.record(
+                                                TraceDecisionUtil.consumeMetricsData(
+                                                        TraceDecisionUtil.MetricType.TRIGGERED_TRACE_COUNT))));
+    }
+
+    @Override
+    public void close() {
+        gauges.forEach(ObservableLongGauge::close);
+    }
+
+
+    @Override
+    public void install(@NonNull InstallationContext installationContext) {
+        collect(installationContext.getOpenTelemetry().getMeterProvider().get("sw.apm.sampling.metrics"));
+        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+    }
+}

--- a/otel-android/src/main/java/com/solarwinds/android/sampling/TraceStateSamplingResult.java
+++ b/otel-android/src/main/java/com/solarwinds/android/sampling/TraceStateSamplingResult.java
@@ -1,0 +1,63 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+public class TraceStateSamplingResult implements SamplingResult {
+  private final SamplingResult delegated;
+  private final Attributes additionalAttributes;
+
+  private TraceStateSamplingResult(
+      SamplingResult delegated, Attributes additionalAttributes) {
+    this.delegated = delegated;
+    this.additionalAttributes = additionalAttributes;
+  }
+
+  public static SamplingResult wrap(
+      SamplingResult result, Attributes additionalAttributes) {
+    return new TraceStateSamplingResult(result, additionalAttributes);
+  }
+
+  @Override
+  public SamplingDecision getDecision() {
+    return delegated.getDecision();
+  }
+
+  @Override
+  public Attributes getAttributes() {
+    return delegated.getAttributes().toBuilder().putAll(additionalAttributes).build();
+  }
+}

--- a/otel-android/src/test/java/com/solarwinds/android/SolarwindsRumBuilderTest.java
+++ b/otel-android/src/test/java/com/solarwinds/android/SolarwindsRumBuilderTest.java
@@ -4,16 +4,13 @@ package com.solarwinds.android;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import android.app.Application;
-
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.work.testing.WorkManagerTestInitHelper;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.api.common.AttributeKey;
@@ -21,19 +18,10 @@ import io.opentelemetry.api.common.Attributes;
 
 @RunWith(AndroidJUnit4.class)
 public class SolarwindsRumBuilderTest {
-    private AutoCloseable mocks;
-
-    @Mock
-    Application application;
 
     @Before
     public void setup() {
-        mocks = MockitoAnnotations.openMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        mocks.close();
+        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext());
     }
 
     @Test
@@ -47,7 +35,7 @@ public class SolarwindsRumBuilderTest {
         solarwindsRumBuilder.otelRumConfig(otelRumConfig)
                 .apiToken("token")
                 .collectorUrl("http://localhost")
-                .build(application);
+                .build(ApplicationProvider.getApplicationContext());
         assertFalse(otelRumConfig.getGlobalAttributesSupplier() instanceof SessionIdAppender);
     }
 
@@ -63,7 +51,7 @@ public class SolarwindsRumBuilderTest {
                 .apiToken("token")
                 .collectorUrl("http://localhost")
                 .sessionProvider(() -> "new-session-id")
-                .build(application);
+                .build(ApplicationProvider.getApplicationContext());
 
         assertInstanceOf(SessionIdAppender.class, otelRumConfig.getGlobalAttributesSupplier());
     }

--- a/otel-android/src/test/java/com/solarwinds/android/sampling/AndroidSettingsFetcherTest.java
+++ b/otel-android/src/test/java/com/solarwinds/android/sampling/AndroidSettingsFetcherTest.java
@@ -1,0 +1,59 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.solarwinds.joboe.sampling.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.mockito.MockedStatic;
+
+@ExtendWith(MockitoExtension.class)
+class AndroidSettingsFetcherTest {
+
+    @InjectMocks
+    private AndroidSettingsFetcher tested;
+
+    @Mock
+    private SettingsListener settingsListenerMock;
+
+    @Mock
+    private Settings settingsMock;
+
+    @Test
+    void doesNotThrowWhenListenerIsNotSet() {
+        assertDoesNotThrow(() -> tested.getSettings());
+    }
+
+    @Test
+    void verifyListenerIsCalled() {
+        tested.registerListener(settingsListenerMock);
+        try (MockedStatic<AndroidSettingsWorker> workerMock = mockStatic(AndroidSettingsWorker.class)) {
+            workerMock.when(AndroidSettingsWorker::getSettings).thenReturn(settingsMock);
+            tested.getSettings();
+            verify(settingsListenerMock).onSettingsRetrieved(any());
+        }
+    }
+}

--- a/otel-android/src/test/java/com/solarwinds/android/sampling/AndroidSettingsWorkerTest.java
+++ b/otel-android/src/test/java/com/solarwinds/android/sampling/AndroidSettingsWorkerTest.java
@@ -1,0 +1,77 @@
+package com.solarwinds.android.sampling;
+
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.work.Data;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkInfo;
+import androidx.work.WorkManager;
+import androidx.work.testing.WorkManagerTestInitHelper;
+
+import com.solarwinds.joboe.sampling.Settings;
+import com.solarwinds.joboe.sampling.SettingsArg;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.ExecutionException;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
+
+@RunWith(AndroidJUnit4.class)
+public class AndroidSettingsWorkerTest {
+    private MockWebServer webServer;
+
+    @Before
+    public void setup() throws IOException {
+        WorkManagerTestInitHelper.initializeTestWorkManager(getApplicationContext());
+        webServer = new MockWebServer();
+        webServer.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        webServer.shutdown();
+    }
+
+    @Test
+    public void testFetchSettings() throws ExecutionException, InterruptedException, IOException {
+        Buffer buffer = new Buffer();
+        InputStream resourceAsStream = AndroidSettingsWorkerTest.class.getResourceAsStream("/solarwinds-config.json");
+        buffer.readFrom(resourceAsStream);
+
+        resourceAsStream.close();
+        webServer.enqueue(new MockResponse().setBody(buffer)
+                .setResponseCode(200));
+
+        Data data = new Data.Builder()
+                .putString("appName", "test-app")
+                .putString("collectorUrl", webServer.url("/").toString())
+                .putString("apiToken", "token")
+                .build();
+
+        OneTimeWorkRequest request =
+                new OneTimeWorkRequest.Builder(AndroidSettingsWorker.class)
+                        .setInputData(data)
+                        .build();
+
+        WorkManager workManager = WorkManager.getInstance(getApplicationContext());
+        workManager.enqueue(request).getResult().get();
+        Settings settings = AndroidSettingsWorker.getSettings();
+
+        assertEquals(120, settings.getTtl());
+        assertEquals(116, settings.getFlags());
+        assertEquals(Integer.valueOf(60), settings.getArgValue(SettingsArg.METRIC_FLUSH_INTERVAL));
+    }
+}

--- a/otel-android/src/test/java/com/solarwinds/android/sampling/SamplingUtilTest.java
+++ b/otel-android/src/test/java/com/solarwinds/android/sampling/SamplingUtilTest.java
@@ -1,0 +1,115 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import static io.opentelemetry.api.common.AttributeKey.booleanKey;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.solarwinds.joboe.sampling.TraceDecision;
+import com.solarwinds.joboe.sampling.TraceDecisionUtil;
+import com.solarwinds.joboe.sampling.XTraceOptions;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SamplingUtilTest {
+
+  @Mock private TraceDecision traceDecisionMock;
+
+  @Test
+  void verifyThatTriggeredTraceAttributeIsAddedForAuthenticatedTriggerTrace() {
+    AttributesBuilder builder = Attributes.builder();
+    XTraceOptions xTraceOptions = XTraceOptions.getXTraceOptions("trigger-trace", null);
+    when(traceDecisionMock.getRequestType())
+        .thenReturn(TraceDecisionUtil.RequestType.AUTHENTICATED_TRIGGER_TRACE);
+
+    SamplingUtil.addXtraceOptionsToAttribute(traceDecisionMock, xTraceOptions, builder);
+    assertEquals(Boolean.TRUE, builder.build().get(booleanKey("TriggeredTrace")));
+  }
+
+  @Test
+  void verifyThatTriggeredTraceAttributeIsAddedForUnauthenticatedTriggerTrace() {
+    AttributesBuilder builder = Attributes.builder();
+    XTraceOptions xTraceOptions = XTraceOptions.getXTraceOptions("trigger-trace", null);
+    when(traceDecisionMock.getRequestType())
+        .thenReturn(TraceDecisionUtil.RequestType.UNAUTHENTICATED_TRIGGER_TRACE);
+
+    SamplingUtil.addXtraceOptionsToAttribute(traceDecisionMock, xTraceOptions, builder);
+    assertEquals(Boolean.TRUE, builder.build().get(booleanKey("TriggeredTrace")));
+  }
+
+  @Test
+  void verifyThatCustomKvAttributesAreAdded() {
+    AttributesBuilder builder = Attributes.builder();
+    XTraceOptions xTraceOptions = XTraceOptions.getXTraceOptions("custom-chubi=chubby;", null);
+    when(traceDecisionMock.getRequestType())
+        .thenReturn(TraceDecisionUtil.RequestType.UNAUTHENTICATED_TRIGGER_TRACE);
+
+    SamplingUtil.addXtraceOptionsToAttribute(traceDecisionMock, xTraceOptions, builder);
+    assertEquals("chubby", builder.build().get(stringKey("custom-chubi")));
+  }
+
+  @Test
+  void verifyThatSwKeysAttributeIsAdded() {
+    AttributesBuilder builder = Attributes.builder();
+    XTraceOptions xTraceOptions =
+        XTraceOptions.getXTraceOptions("sw-keys=lo:se,check-id:123", null);
+    when(traceDecisionMock.getRequestType())
+        .thenReturn(TraceDecisionUtil.RequestType.AUTHENTICATED_TRIGGER_TRACE);
+
+    SamplingUtil.addXtraceOptionsToAttribute(traceDecisionMock, xTraceOptions, builder);
+    assertEquals("lo:se,check-id:123", builder.build().get(stringKey("SWKeys")));
+  }
+
+  @Test
+  void returnTrueGivenValidSwTraceState() {
+    String swTraceState = "4025843a0f1f35f3-01";
+    assertTrue(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithInvalidFlag() {
+    String swTraceState = "4025843a0f1f35f3-11";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithSpanIdLengthLessThan16() {
+    String swTraceState = "4025843a0f1f35f-01";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithSpanIdLengthGreaterThan16() {
+    String swTraceState = "4025843a0f1f35f33-01";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+
+  @Test
+  void returnFalseGivenSwTraceStateWithInvalidFormat() {
+    String swTraceState = "4025843a0f1f3-5f-01";
+    assertFalse(SamplingUtil.isValidSwTraceState(swTraceState));
+  }
+}

--- a/otel-android/src/test/java/com/solarwinds/android/sampling/SolarwindsSamplerTest.java
+++ b/otel-android/src/test/java/com/solarwinds/android/sampling/SolarwindsSamplerTest.java
@@ -1,0 +1,292 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import static com.solarwinds.android.sampling.SamplingUtil.w3cContextToHexString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.solarwinds.joboe.sampling.TraceConfig;
+import com.solarwinds.joboe.sampling.TraceDecision;
+import com.solarwinds.joboe.sampling.TraceDecisionUtil;
+import com.solarwinds.joboe.sampling.XTraceOptions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.samplers.SamplingDecision;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+
+@RunWith(AndroidJUnit4.class)
+public class SolarwindsSamplerTest {
+
+    @InjectMocks
+    private SolarwindsSampler tested;
+
+    @Mock
+    private TraceDecision traceDecisionMock;
+
+    @Mock
+    private XTraceOptions xTraceOptionsMock;
+
+    @Mock
+    private TraceConfig traceConfigMock;
+
+    @Mock
+    private SpanContext spanContextMock;
+
+    @Mock
+    private Span spanMock;
+
+    @Mock
+    private TraceState traceStateMock;
+
+    @Captor
+    private ArgumentCaptor<String> stringArgumentCaptor;
+
+    private final IdGenerator idGenerator = IdGenerator.random();
+
+    private AutoCloseable mocks;
+
+    @Before
+    public void setup() {
+        mocks = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void teardown() throws Exception {
+        mocks.close();
+    }
+
+    @Test
+    public void returnSamplingResultGivenTraceDecisionIsSampled() {
+        when(traceDecisionMock.isSampled()).thenReturn(true);
+        when(traceDecisionMock.getTraceConfig()).thenReturn(traceConfigMock);
+        when(traceConfigMock.getSampleRate()).thenReturn(100);
+
+        when(traceConfigMock.getSampleRateSourceValue()).thenReturn(2);
+        when(traceConfigMock.getBucketRate(any())).thenReturn(0.5);
+        when(traceConfigMock.getBucketCapacity(any())).thenReturn(0.5);
+
+        when(traceDecisionMock.getRequestType()).thenReturn(TraceDecisionUtil.RequestType.REGULAR);
+        when(traceDecisionMock.isReportMetrics()).thenReturn(true);
+
+        tested.toOtSamplingResult(traceDecisionMock, xTraceOptionsMock, false);
+
+        verify(traceDecisionMock, atLeastOnce()).getTraceConfig();
+        verify(traceConfigMock, atLeastOnce()).getSampleRate();
+    }
+
+    @Test
+    public void returnSamplingResultGivenTraceDecisionIsMetricsOnly() {
+        when(traceDecisionMock.isSampled()).thenReturn(false);
+        when(traceDecisionMock.isReportMetrics()).thenReturn(true);
+
+        SamplingResult actual = tested.toOtSamplingResult(traceDecisionMock, xTraceOptionsMock, false);
+        assertEquals(SolarwindsSampler.METRICS_ONLY, actual);
+    }
+
+    @Test
+    public void returnSamplingResultGivenTraceDecisionIsNotSample() {
+        when(traceDecisionMock.isSampled()).thenReturn(false);
+        when(traceDecisionMock.isReportMetrics()).thenReturn(false);
+
+        SamplingResult actual = tested.toOtSamplingResult(traceDecisionMock, xTraceOptionsMock, false);
+        assertEquals(SolarwindsSampler.NOT_TRACED, actual);
+    }
+
+    @Test
+    public void verifyThatLocalTraceDecisionMachineryIsUsedWhenSpanIsRoot() {
+        try (MockedStatic<Span> spanMockedStatic = mockStatic(Span.class);
+             MockedStatic<TraceDecisionUtil> traceDecisionUtilMockedStatic =
+                     mockStatic(TraceDecisionUtil.class)) {
+            spanMockedStatic.when(() -> Span.fromContext(any())).thenReturn(spanMock);
+            traceDecisionUtilMockedStatic
+                    .when(
+                            () ->
+                                    TraceDecisionUtil.shouldTraceRequest(
+                                            any(), stringArgumentCaptor.capture(), any(), any()))
+                    .thenReturn(traceDecisionMock);
+
+            when(spanContextMock.isValid()).thenReturn(false);
+            when(traceDecisionMock.isSampled()).thenReturn(false);
+            when(traceDecisionMock.isReportMetrics()).thenReturn(false);
+
+            when(spanMock.getSpanContext()).thenReturn(spanContextMock);
+            tested.shouldSample(
+                    Context.current(),
+                    idGenerator.generateTraceId(),
+                    "name",
+                    SpanKind.INTERNAL,
+                    Attributes.empty(),
+                    Collections.emptyList());
+
+            traceDecisionUtilMockedStatic.verify(
+                    () -> TraceDecisionUtil.shouldTraceRequest(any(), any(), any(), any()));
+            assertNull(stringArgumentCaptor.getValue());
+        }
+    }
+
+    @Test
+    public void verifyThatTraceDecisionMachineryIsUsedWhenSpanParentIsRemoteAndSwTraceStateIsInvalid() {
+        try (MockedStatic<Span> spanMockedStatic = mockStatic(Span.class);
+             MockedStatic<TraceDecisionUtil> traceDecisionUtilMockedStatic =
+                     mockStatic(TraceDecisionUtil.class)) {
+            spanMockedStatic.when(() -> Span.fromContext(any())).thenReturn(spanMock);
+            traceDecisionUtilMockedStatic
+                    .when(() -> TraceDecisionUtil.shouldTraceRequest(any(), any(), any(), any()))
+                    .thenReturn(traceDecisionMock);
+
+            when(spanContextMock.isValid()).thenReturn(true);
+            when(traceDecisionMock.isSampled()).thenReturn(false);
+            when(traceDecisionMock.isReportMetrics()).thenReturn(false);
+
+            when(spanMock.getSpanContext()).thenReturn(spanContextMock);
+            when(spanContextMock.getTraceState()).thenReturn(traceStateMock);
+            when(traceStateMock.get(any())).thenReturn("this is illegal");
+
+            when(spanContextMock.isRemote()).thenReturn(true);
+            tested.shouldSample(
+                    Context.current(),
+                    idGenerator.generateTraceId(),
+                    "name",
+                    SpanKind.INTERNAL,
+                    Attributes.empty(),
+                    Collections.emptyList());
+
+            traceDecisionUtilMockedStatic.verify(
+                    () -> TraceDecisionUtil.shouldTraceRequest(any(), any(), any(), any()));
+        }
+    }
+
+    @Test
+    public void verifyThatTraceDecisionMachineryIsUsedWhenSpanParentIsRemoteAndSwTraceStateIsValid() {
+        try (MockedStatic<Span> spanMockedStatic = mockStatic(Span.class);
+             MockedStatic<TraceDecisionUtil> traceDecisionUtilMockedStatic =
+                     mockStatic(TraceDecisionUtil.class);
+             MockedStatic<SamplingUtil> utilMockedStatic = mockStatic(SamplingUtil.class)) {
+            spanMockedStatic.when(() -> Span.fromContext(any())).thenReturn(spanMock);
+            traceDecisionUtilMockedStatic
+                    .when(() -> TraceDecisionUtil.shouldTraceRequest(any(), any(), any(), any()))
+                    .thenReturn(traceDecisionMock);
+
+            String traceId = idGenerator.generateTraceId();
+            utilMockedStatic.when(() -> SamplingUtil.w3cContextToHexString(spanContextMock)).thenReturn(traceId);
+            utilMockedStatic.when(() -> SamplingUtil.isValidSwTraceState(anyString())).thenReturn(true);
+
+            String spanId = idGenerator.generateSpanId();
+            String swVal = String.format("%s-%s", spanId, "01");
+            when(spanContextMock.isRemote()).thenReturn(true);
+
+            when(spanContextMock.isValid()).thenReturn(true);
+            when(traceDecisionMock.isSampled()).thenReturn(false);
+            when(traceDecisionMock.isReportMetrics()).thenReturn(false);
+
+            when(spanMock.getSpanContext()).thenReturn(spanContextMock);
+            when(spanContextMock.getTraceState()).thenReturn(traceStateMock);
+            when(traceStateMock.get(any())).thenReturn(swVal);
+
+            tested.shouldSample(
+                    Context.current(),
+                    idGenerator.generateTraceId(),
+                    "name",
+                    SpanKind.INTERNAL,
+                    Attributes.empty(),
+                    Collections.emptyList());
+
+            traceDecisionUtilMockedStatic.verify(
+                    () ->
+                            TraceDecisionUtil.shouldTraceRequest(
+                                    any(), stringArgumentCaptor.capture(), any(), any()));
+            utilMockedStatic.verify(() -> SamplingUtil.w3cContextToHexString(spanContextMock));
+
+            assertEquals(traceId, stringArgumentCaptor.getValue());
+        }
+    }
+
+    @Test
+    public void returnRecordAndSampleDecisionWhenSpanIsLocalAndParentIsSample() {
+        try (MockedStatic<Span> spanMockedStatic = mockStatic(Span.class)) {
+            spanMockedStatic.when(() -> Span.fromContext(any())).thenReturn(spanMock);
+            when(spanMock.getSpanContext()).thenReturn(spanContextMock);
+            when(spanContextMock.isRemote()).thenReturn(false);
+
+            when(spanContextMock.isValid()).thenReturn(true);
+            when(spanContextMock.isSampled()).thenReturn(true);
+            when(spanContextMock.getTraceState()).thenReturn(traceStateMock);
+
+            SamplingResult actual =
+                    tested.shouldSample(
+                            Context.current(),
+                            idGenerator.generateTraceId(),
+                            "name",
+                            SpanKind.INTERNAL,
+                            Attributes.empty(),
+                            Collections.emptyList());
+
+            assertEquals(SamplingDecision.RECORD_AND_SAMPLE, actual.getDecision());
+        }
+    }
+
+    @Test
+    public void returnDropDecisionWhenLocalSpanAndParentIsNotSampled() {
+        try (MockedStatic<Span> spanMockedStatic = mockStatic(Span.class)) {
+            spanMockedStatic.when(() -> Span.fromContext(any())).thenReturn(spanMock);
+            when(spanMock.getSpanContext()).thenReturn(spanContextMock);
+
+            when(spanContextMock.isRemote()).thenReturn(false);
+            when(spanContextMock.isValid()).thenReturn(true);
+            when(spanContextMock.getTraceState()).thenReturn(traceStateMock);
+
+            SamplingResult actual =
+                    tested.shouldSample(
+                            Context.current(),
+                            idGenerator.generateTraceId(),
+                            "name",
+                            SpanKind.INTERNAL,
+                            Attributes.empty(),
+                            Collections.emptyList());
+
+            assertEquals(SamplingDecision.DROP, actual.getDecision());
+        }
+    }
+}

--- a/otel-android/src/test/java/com/solarwinds/android/sampling/TraceDecisionMetricCollectorTest.java
+++ b/otel-android/src/test/java/com/solarwinds/android/sampling/TraceDecisionMetricCollectorTest.java
@@ -1,0 +1,98 @@
+/*
+ * © SolarWinds Worldwide, LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solarwinds.android.sampling;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Consumer;
+
+import io.opentelemetry.android.instrumentation.InstallationContext;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
+import io.opentelemetry.api.metrics.LongGaugeBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+
+@ExtendWith(MockitoExtension.class)
+class TraceDecisionMetricCollectorTest {
+    private final TraceDecisionMetricCollector tested = new TraceDecisionMetricCollector();
+
+    @Mock
+    private ObservableLongMeasurement observableLongMeasurementMock;
+
+    @Mock
+    private Meter meterMock;
+
+    @Mock
+    private DoubleGaugeBuilder doubleGaugeBuilderMock;
+
+    @Mock
+    private LongGaugeBuilder longGaugeBuilderMock;
+
+    @Mock
+    private InstallationContext installationContextMock;
+
+    @Mock
+    private OpenTelemetry openTelemetryMock;
+
+    @Mock
+    private MeterProvider meterProviderMock;
+
+    @Captor
+    private ArgumentCaptor<Consumer<ObservableLongMeasurement>> consumerArgumentCaptor;
+
+    @Test
+    void verifyThatAllGaugesCallbackIsExecutedExcludingQueueBasedOnes() {
+        when(meterMock.gaugeBuilder(anyString())).thenReturn(doubleGaugeBuilderMock);
+        when(doubleGaugeBuilderMock.ofLongs()).thenReturn(longGaugeBuilderMock);
+
+        tested.collect(meterMock);
+        verify(longGaugeBuilderMock, atLeastOnce()).buildWithCallback(consumerArgumentCaptor.capture());
+
+        consumerArgumentCaptor
+                .getAllValues()
+                .forEach(consumer -> consumer.accept(observableLongMeasurementMock));
+        verify(observableLongMeasurementMock, times(6)).record(anyLong());
+    }
+
+    @Test
+    void verifyMetricsActivated() {
+        when(meterMock.gaugeBuilder(anyString())).thenReturn(doubleGaugeBuilderMock);
+        when(doubleGaugeBuilderMock.ofLongs()).thenReturn(longGaugeBuilderMock);
+        when(installationContextMock.getOpenTelemetry()).thenReturn(openTelemetryMock);
+
+        when(openTelemetryMock.getMeterProvider()).thenReturn(meterProviderMock);
+        when(meterProviderMock.get(anyString())).thenReturn(meterMock);
+
+        tested.install(installationContextMock);
+        verify(meterMock, atMost(10)).gaugeBuilder(anyString());
+    }
+}

--- a/otel-android/src/test/resources/solarwinds-config.json
+++ b/otel-android/src/test/resources/solarwinds-config.json
@@ -1,0 +1,18 @@
+{
+  "arguments": {
+    "BucketCapacity": 2,
+    "BucketRate": 1,
+    "MetricsFlushInterval": 60,
+    "SignatureKey": "0sftj1EYX7JJp01DblJwkccYCIZ91fbU",
+    "TriggerRelaxedBucketCapacity": 20,
+    "TriggerRelaxedBucketRate": 1,
+    "TriggerStrictBucketCapacity": 6,
+    "TriggerStrictBucketRate": 0.1
+  },
+  "flags": "SAMPLE_START,SAMPLE_THROUGH_ALWAYS,SAMPLE_BUCKET_ENABLED,TRIGGER_TRACE",
+  "layer": "",
+  "timestamp": 1698176407,
+  "ttl": 120,
+  "type": 0,
+  "value": 1000000
+}

--- a/sample-app/src/main/java/com/solarwinds/devthoughts/data/DevThoughtsDatabase.kt
+++ b/sample-app/src/main/java/com/solarwinds/devthoughts/data/DevThoughtsDatabase.kt
@@ -21,7 +21,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [Dev::class, Thought::class], version = 1)
+@Database(entities = [Dev::class, Thought::class], version = 1, exportSchema = false)
 abstract class DevThoughtsDatabase : RoomDatabase() {
 
     abstract fun devDao(): DevDao

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,14 @@ dependencyResolutionManagement {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
             mavenContent { snapshotsOnly() }
         }
+
+        maven {
+            url = uri("https://maven.pkg.github.com/solarwinds/joboe")
+            credentials {
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
**Tl;dr**: add sampling

**Context**:

This adds sampling using the current sampling approach which retrieves sampling rate from server. Settings retrieval is schedule using Android work manager API. Though, we request to be scheduled every 60 seconds, the system will do so only when resources are available based on specified constraints and other system constraints.

Most the classes were copied from `apm-java` with little to no modification.

**Test Plan**:

Unit tests and manual testing

